### PR TITLE
예약현황이 없을 경우 달력 조회가 안되던 오류 수정(예약이 애초에 없으면 populate해서 못가져와서 생긴 문제 숙소 id…

### DIFF
--- a/routers/reservationController.js
+++ b/routers/reservationController.js
@@ -165,16 +165,16 @@ reservationRouter.get("/:id/:year/:month", async (req, res) => {
 
         // 캘린더에 수용 가능한 인원 추가
         Object.keys(calendar).forEach(date => {
-            const capacity = reservations[0].accommodation.accommodatedPerson;
+            const accommodation = Accommodation.findById(accommodation_id);
+            const capacity = accommodation.accommodatedPerson;
+            const spaceType = accommodation.spaceType;
+
             const reservePeople = calendar[date]?.reservePeople || 0;
 
             if (reservations.length > 0) {
-                const spaceType = reservations[0].accommodation.spaceType;
-
                 let remainingCapacity;
                 if (spaceType === 'ENTIRE_PLACE') {
                     calendar[date].remainingCapacity = reservePeople === 0 ? 'O' : 'X';
-
 
                 } else if (spaceType === 'PRIVATE_ROOM') {
                     remainingCapacity = capacity - reservePeople;

--- a/services/accommodationService.js
+++ b/services/accommodationService.js
@@ -101,6 +101,19 @@ async function findHouseDetail(accommodation_id) {
         });
     }
 
+    // 입력값이 유효한지 확인하는 함수
+    function validateYear(input) {
+        const currentYear = new Date().getFullYear();
+        const yearRegex = /^\d{4}$/;
+        const parsedYear = parseInt(input, 10);
+        return yearRegex.test(input) && parsedYear >= currentYear;
+    }
+
+
+    function validateMonth(input) {
+        const monthNumber = parseInt(input, 10);
+        return !isNaN(monthNumber) && monthNumber >= 1 && monthNumber <= 12;
+    }
 
     try {
         const reservation = await axios.get(`http://127.0.0.1:3000/reservation/${accommodation_id}`);
@@ -108,10 +121,22 @@ async function findHouseDetail(accommodation_id) {
         printReviews(review.data)
         console.log()
         displayCalendar(reservation.data);
-        const year = rl.question("\n 조회하고 싶은 년도 : ")
-        const month = rl.question("\n 조회하고 싶은 달 : ")
-        const reservation_want = await axios.get(`http://127.0.0.1:3000/reservation/${accommodation_id}/${year}/${month}`);
-        displayCalendar(reservation_want.data)
+        while (true) {
+            const year = rl.question("\n조회하고 싶은 년도 : ")
+            if(validateYear(year)){
+                const month = rl.question("\n조회하고 싶은 달 : ")
+                if(validateMonth(month)){
+                    const reservation_want = await axios.get(`http://127.0.0.1:3000/reservation/${accommodation_id}/${year}/${month}`);
+                    displayCalendar(reservation_want.data)
+                }else{
+                    break;
+                }
+            }else{
+                break;
+            }
+        }
+        console.log("상세조회를 종료합니다.")
+
 
         // 이후 reservation을 처리하는 코드 추가
     } catch (error) {


### PR DESCRIPTION
…로 그냥 숙소테이블에서 받아옴)

달력 조회 무한 루프 적용
연도 : 현재 연도보다 이전연도 or 4자리 넘어가는 연도 조회시 break;
달 : 1~12말고 다른 숫자 입력시 break;